### PR TITLE
Log config read and updates README about Flit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
+# lint-diffs
+
 [![Build Status](https://travis-ci.com/AtakamaLLC/lint-diffs.svg?branch=master)](https://travis-ci.com/AtakamaLLC/lint-diffs)
 [![Code Coverage](https://codecov.io/gh/AtakamaLLC/lint-diffs/branch/master/graph/badge.svg)](https://codecov.io/gh/AtakamaLLC/lint-diffs)
-
-# lint-diffs
 
 lint-diffs is a simple command line tool for running a set of arbitrarty linters
 on a set of 'unified diffs'.
@@ -15,12 +15,12 @@ First you need some diffs, then you pipe it to lint-diffs:
 
 ... or in mercurial: `hg outgoing -p | lint-diffs`
 
--   default linter configuration is on for pylint (.py), rubocop (.rb), and 
-    clang (.cpp, .hpp)
+-   default linter configuration is on for pylint (.py), rubocop (.rb), and
+      clang (.cpp, .hpp)
 
 -   flake8, eslint and other linters need to be enabled (see below) explicitly.
 
-Configuration:
+## Configuration
 
 `lint-diffs` will read a config files from `~/.config/lint-diffs` and/or `./.lint-diffs`.
 
@@ -49,17 +49,25 @@ Additionally, ruby, eslint and shell script linters have been enabled.   The
 ruby linter has been modified to always report warnings, on any changed file,
 not just changed lines.
 
-To add new linters:
+## To add new linters
 
 -   The linter has to report to stdout
+
 -   The linter has to have a regex that produces a full file path, a line number
     and an error class
+
 -   The line numbers and file paths have to match diff target file paths
 
 To enable or disable linters change the 'extensions' config.
 
-Goals:
+## Goals
 
 -   Runs with good defaults for many people
 -   Should be easy to modify the config for any linter
 -   Should be easy to use with any vcs
+
+## Development
+
+This project uses [Flit](https://flit.readthedocs.io/en/latest/) to build its
+packages. That might answer your question in case you are wondering why there
+is no **setup.py** here.

--- a/lint_diffs/__init__.py
+++ b/lint_diffs/__init__.py
@@ -264,7 +264,11 @@ def main():
     # if this is a problem, remove it
     logging.basicConfig()
 
+    # Read command line arguments and turn on DEBUG logging if asked for so
+    # we can check for debugging information while parsing configuration files
     args = _parse_args()
+    if args.debug:
+        log.setLevel(logging.DEBUG)
 
     py_config = read_config()
 

--- a/lint_diffs/__init__.py
+++ b/lint_diffs/__init__.py
@@ -24,7 +24,7 @@ from unidiff import PatchSet
 
 log = logging.getLogger("lint_diffs")
 __all__ = ["main"]
-__version__ = "0.1.20"
+__version__ = "0.1.21"
 USER_CONFIG = "~/.config/lint-diffs"
 CONSOLE_LOCK = Lock()
 NOTFOUND = -9


### PR DESCRIPTION
Without https://github.com/AtakamaLLC/lint-diffs/pull/10/commits/ecfb18dc092b7c4f02e7e723806237df10f503f5 we are not able to get debugging information about configuration being loaded.

Added some information about Flit, just in case some developer, keeps wondering about why there is no **setup.py** file.

Other than that, just some lint changes on README file.