### PR TITLE
Bare output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,16 @@ Goals:
 -   Runs with good defaults for many people
 -   Should be easy to modify the config for any linter
 -   Should be easy to use with any vcs
+
+## Running in Bare mode
+
+In case you intend to integrate this with some other tool or IDE, you might
+wish to get only the output for one single linter to the console. In that case
+you can use the **--bare** command line option passing a linter name to obtain
+an output like this:
+
+```console
+$ git diff -U0 origin/master | lint-diffs --bare flake8
+lint_diffs/__init__.py:194:54: W291 trailing whitespace
+lint_diffs/__init__.py:334:68: W291 trailing whitespace
+```

--- a/test/test_lintr.py
+++ b/test/test_lintr.py
@@ -298,3 +298,12 @@ def test_not_strict():
     with patch.object(sys, "stdin", io.StringIO(DIFF_OUTPUT)), patch("sys.exit") as exited:
         main()
         exited.assert_not_called()
+
+
+def test_bare(capsys):
+    sys.argv = ["whatever", "--bare", "pylint"]
+    with patch.object(sys, "stdin", io.StringIO(DIFF_OUTPUT)), patch("sys.exit") as exited:
+        main()
+    cap = capsys.readouterr()
+    lines = cap.out.split('\n')
+    assert len(lines) == 2, "Expected only bare output"


### PR DESCRIPTION
This pull-request brings new command line option **--bare** to allow integrating one linter with other script tools or editors environments. The idea is to make sure only one linter gets used when that option is set and that only its raw output will be printed to _stdout_. Other tools could then parse that lint output to show, lets say, in a text editor or CI pipeline, whether a given change-set or lines being touched contains error.

Test and README information were added.
